### PR TITLE
Create a flysystem.mount_manager service

### DIFF
--- a/src/FlysystemServiceProviderTrait.php
+++ b/src/FlysystemServiceProviderTrait.php
@@ -2,6 +2,7 @@
 
 namespace WyriHaximus\Pimple;
 
+use League\Flysystem\MountManager;
 use Pimple\Container;
 use League\Flysystem\Filesystem;
 use League\Flysystem\Plugin\EmptyDir;
@@ -35,6 +36,14 @@ trait FlysystemServiceProviderTrait
                 $flysystems[$alias] = $this->buildFilesystem($app, $parameters);
             }
             return $flysystems;
+        };
+
+        $app['flysystem.mount_manager'] = function (Container $app) {
+            $mountManager = new MountManager();
+            foreach ($app['flysystem.filesystems'] as $alias => $parameters) {
+                $mountManager->mountFilesystem($alias, $app['flysystems'][$alias]);
+            }
+            return $mountManager;
         };
     }
 

--- a/tests/FlysystemServiceProviderTraitTest.php
+++ b/tests/FlysystemServiceProviderTraitTest.php
@@ -20,9 +20,25 @@ class FlysystemServiceProviderTraitTest extends \PHPUnit_Framework_TestCase
                     'foo' => 'bar',
                 ],
             ],
+            'local2' => [
+                'adapter' => 'League\Flysystem\Adapter\Local',
+                'args' => [
+                    __DIR__,
+                ],
+            ],
         ];
+
         $this->assertInstanceOf('League\Flysystem\Filesystem', $pimple['flysystems']['local']);
         $this->assertTrue($pimple['flysystems']['local']->getConfig()->has('foo'));
         $this->assertSame('bar', $pimple['flysystems']['local']->getConfig()->get('foo'));
+
+        $this->assertInstanceOf('League\Flysystem\MountManager', $pimple['flysystem.mount_manager']);
+
+        $this->assertInstanceOf('League\Flysystem\Filesystem', $pimple['flysystem.mount_manager']->getFilesystem('local'));
+        $this->assertInstanceOf('League\Flysystem\Filesystem', $pimple['flysystem.mount_manager']->getFilesystem('local2'));
+
+        $pimple['flysystem.mount_manager']->mountFilesystem('local', $pimple['flysystems']['local']);
+
+        $this->assertTrue($pimple['flysystem.mount_manager']->has('local://' . basename(__FILE__)));
     }
 }


### PR DESCRIPTION
Create a flysystem.mount_manager service that allow users to leverage the MountManager cross file system operations (see http://flysystem.thephpleague.com/mount-manager/)